### PR TITLE
change opening example

### DIFF
--- a/population/README.md
+++ b/population/README.md
@@ -6,7 +6,7 @@ Determine how long it takes for a population to reach a particular size.
 $ ./population
 Start size: 100
 End size: 200
-9 years
+Years: 9
 ```
 
 ## Populations


### PR DESCRIPTION
Changed the opening example execution "9 years" to "Years: 9"  to match all of the examples given in the Testing section.