### PR TITLE
Update __init__.py in half to include better help messages.

### DIFF
--- a/half/__init__.py
+++ b/half/__init__.py
@@ -46,4 +46,12 @@ def regex(input):
 
 
 def check_half(bill: str, tax: str, tip: str, expected: str):
-    check50.run("./half").stdin(bill).stdin(tax).stdin(tip).stdout(regex(expected), expected, regex=True)
+    output = check50.run("./half").stdin(bill).stdin(tax).stdin(tip).stdout()
+    regex_output = re.search(regex(expected), output)
+    if regex_output == None:
+        if "$" not in output:
+            help = "Are you sure you included a dollar sign?"
+        else:
+            help = "Are you sure the string contains the correct dollar amount?"
+
+        raise check50.Missing(f"${expected}", output, help=help)


### PR DESCRIPTION
Previously, help messages in the half problem were incredibly erroneous. If you were to get it wrong, it would say: `Expected 64.00, not 32.00`. The problem with this message is that check50 also expects a dollar sign in the number, and the number can be anywhere in the string. This PR can hopefully help clear up issues where people remove the dollar sign accidentally, and are confused when check50 errors with the output it 'expects'. It now uses check50.Missing() instead of just the default stdout().