### PR TITLE
add valgrind to license checks

### DIFF
--- a/license/__init__.py
+++ b/license/__init__.py
@@ -19,3 +19,9 @@ def compiles():
 def valid():
     """license prints all plates."""
     check50.run("./license plates.txt").stdout("11ZT00\n1KAD21\n78ZZ01\n99ZZ11\n72ZZ21\n98ZZ31\n44ZW41\n34ZZ51")
+
+
+@check50.check(compiles)
+def frees_memory():
+    """results in no memory leakages"""
+    check50.c.valgrind("./license plates.txt").exit(0)


### PR DESCRIPTION
Added a valgrind check to the [license](https://cs50.harvard.edu/x/2024/practice/license/) checks.

Similar to the check done for [inheritance](https://cs50.harvard.edu/x/2024/psets/5/inheritance/)